### PR TITLE
OS-2145; Set error message on protocol negotiation failure. 

### DIFF
--- a/libfreerdp-core/connection.c
+++ b/libfreerdp-core/connection.c
@@ -81,8 +81,7 @@ tbool rdp_client_connect(rdpRdp* rdp)
 	if (nego_connect(rdp->nego) == false)
 	{
 		printf("Error: protocol security negotiation failure\n");
-		if (!freerdp_get_last_error(rdp->instance->context))
-			freerdp_set_last_error(rdp->instance->context, FREERDP_ERROR_SECURITY_NEGO_CONNECT_FAILED);
+		freerdp_set_last_error(rdp->instance->context, FREERDP_ERROR_SECURITY_NEGO_CONNECT_FAILED);
 		return false;
 	}
 
@@ -111,8 +110,7 @@ tbool rdp_client_connect(rdpRdp* rdp)
 	if (status == false)
 	{
 		printf("Error: transport connect failure\n");
-		if (!freerdp_get_last_error(rdp->instance->context))
-			freerdp_set_last_error(rdp->instance->context, FREERDP_ERROR_CONNECT_TRANSPORT_FAILED);
+		freerdp_set_last_error(rdp->instance->context, FREERDP_ERROR_CONNECT_TRANSPORT_FAILED);
 		return false;
 	}
 

--- a/libfreerdp-core/connection.c
+++ b/libfreerdp-core/connection.c
@@ -110,6 +110,9 @@ tbool rdp_client_connect(rdpRdp* rdp)
 
 	if (status == false)
 	{
+		printf("Error: transport connect failure\n");
+		if (!freerdp_get_last_error(rdp->instance->context))
+			freerdp_set_last_error(rdp->instance->context, FREERDP_ERROR_CONNECT_TRANSPORT_FAILED);
 		return false;
 	}
 

--- a/libfreerdp-core/connection.c
+++ b/libfreerdp-core/connection.c
@@ -81,6 +81,8 @@ tbool rdp_client_connect(rdpRdp* rdp)
 	if (nego_connect(rdp->nego) == false)
 	{
 		printf("Error: protocol security negotiation failure\n");
+		if (!freerdp_get_last_error(rdp->instance->context))
+			freerdp_set_last_error(rdp->instance->context, FREERDP_ERROR_SECURITY_NEGO_CONNECT_FAILED);
 		return false;
 	}
 


### PR DESCRIPTION
If XRDP was not passed a password or username, XRDP would disable checking for NLA, because it could not possibly do NLA without valid credentials. 
However, if the device was set to force NLA, then the protocol negotiation would fail, but **not** set the error message. This left the error code as 0 (success) which was presented to the user. 

I have also addressed another case of this if transport connection failed. 