### PR TITLE
client: fetch client time zone on pre_connect

### DIFF
--- a/client/DirectFB/dfreerdp.c
+++ b/client/DirectFB/dfreerdp.c
@@ -24,6 +24,7 @@
 #include <freerdp/utils/memory.h>
 #include <freerdp/utils/semaphore.h>
 #include <freerdp/utils/event.h>
+#include <freerdp/utils/time.h>
 #include <freerdp/constants.h>
 #include <freerdp/plugins/cliprdr.h>
 
@@ -153,6 +154,8 @@ tbool df_pre_connect(freerdp* instance)
 	dfi->clrconv->invert = 0;
 	dfi->clrconv->rgb555 = 0;
 	dfi->clrconv->palette = xnew(rdpPalette);
+
+	time_set_client_time_zone(settings);
 
 	freerdp_channels_pre_connect(instance->context->channels, instance);
 

--- a/client/Windows/wfreerdp.c
+++ b/client/Windows/wfreerdp.c
@@ -34,6 +34,7 @@
 #include <freerdp/utils/args.h>
 #include <freerdp/utils/event.h>
 #include <freerdp/utils/memory.h>
+#include <freerdp/utils/time.h>
 #include <freerdp/channels/channels.h>
 
 #include "wf_gdi.h"
@@ -209,6 +210,9 @@ tbool wf_pre_connect(freerdp* instance)
 	}
 
 	settings->kbd_layout = (int) GetKeyboardLayout(0) & 0x0000FFFF;
+
+	time_set_client_time_zone(settings);
+
 	freerdp_channels_pre_connect(instance->context->channels, instance);
 
 	return true;

--- a/client/X11/xfreerdp.c
+++ b/client/X11/xfreerdp.c
@@ -52,6 +52,7 @@
 #include <freerdp/utils/event.h>
 #include <freerdp/utils/signal.h>
 #include <freerdp/utils/passphrase.h>
+#include <freerdp/utils/time.h>
 #include <freerdp/plugins/cliprdr.h>
 #include <freerdp/rail.h>
 
@@ -508,6 +509,8 @@ tbool xf_pre_connect(freerdp* instance)
 	settings->order_support[NEG_ELLIPSE_CB_INDEX] = false;
 
 	freerdp_channels_pre_connect(xfi->_context->channels, instance);
+
+	time_set_client_time_zone(settings);
 
 	xfi->display = XOpenDisplay(NULL);
 

--- a/include/freerdp/utils/time.h
+++ b/include/freerdp/utils/time.h
@@ -1,0 +1,27 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol client.
+ * Time Utils
+ *
+ * Copyright 2018 Idan Freiberg <speidy@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __TIME_UTILS_H
+#define __TIME_UTILS_H
+
+#include <freerdp/settings.h>
+
+void time_set_client_time_zone(rdpSettings* settings);
+
+#endif /* __TIME_UTILS_H */

--- a/libfreerdp-core/info.h
+++ b/libfreerdp-core/info.h
@@ -72,7 +72,6 @@
 
 void rdp_read_system_time(STREAM* s, SYSTEM_TIME* system_time);
 void rdp_write_system_time(STREAM* s, SYSTEM_TIME* system_time);
-void rdp_get_client_time_zone(STREAM* s, rdpSettings* settings);
 boolean rdp_read_client_time_zone(STREAM* s, rdpSettings* settings);
 void rdp_write_client_time_zone(STREAM* s, rdpSettings* settings);
 void rdp_read_server_auto_reconnect_cookie(STREAM* s, rdpSettings* settings);

--- a/libfreerdp-utils/CMakeLists.txt
+++ b/libfreerdp-utils/CMakeLists.txt
@@ -46,6 +46,7 @@ set(FREERDP_UTILS_SRCS
 	string.c
 	svc_plugin.c
 	thread.c
+	time.c
 	unicode.c
 	wait_obj.c
 	git_ref.h)

--- a/libfreerdp-utils/time.c
+++ b/libfreerdp-utils/time.c
@@ -1,0 +1,69 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol client.
+ * Time Utils
+ *
+ * Copyright 2018 Idan Freiberg <speidy@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <time.h>
+
+#include <freerdp/utils/time.h>
+
+
+/**
+ * Set client time zone information.
+ * @param settings settings
+ */
+
+void time_set_client_time_zone(rdpSettings* settings)
+{
+	time_t t;
+	struct tm* local_time;
+	TIME_ZONE_INFO* clientTimeZone;
+
+	time(&t);
+	local_time = localtime(&t);
+	clientTimeZone = settings->client_time_zone;
+
+#if defined(sun)
+	if(local_time->tm_isdst > 0)
+		clientTimeZone->bias = (uint32) (altzone / 3600);
+	else
+		clientTimeZone->bias = (uint32) (timezone / 3600);
+#elif defined(HAVE_TM_GMTOFF)
+	if(local_time->tm_gmtoff >= 0)
+		clientTimeZone->bias = (uint32) (local_time->tm_gmtoff / 60);
+	else
+		clientTimeZone->bias = (uint32) ((-1 * local_time->tm_gmtoff) / 60 + 720);
+#else
+	clientTimeZone->bias = 0;
+#endif
+
+	if(local_time->tm_isdst > 0)
+	{
+		clientTimeZone->standardBias = clientTimeZone->bias - 60;
+		clientTimeZone->daylightBias = clientTimeZone->bias;
+	}
+	else
+	{
+		clientTimeZone->standardBias = clientTimeZone->bias;
+		clientTimeZone->daylightBias = clientTimeZone->bias + 60;
+	}
+
+	strftime(clientTimeZone->standardName, 32, "%Z, Standard Time", local_time);
+	clientTimeZone->standardName[31] = 0;
+	strftime(clientTimeZone->daylightName, 32, "%Z, Summer Time", local_time);
+	clientTimeZone->daylightName[31] = 0;
+}


### PR DESCRIPTION
The current code is fetching the client time zone info at the serialization library which is incorrect and breaks the design of libfreerdp-core.
Setting client specific settings is a responsibility of the client.
Since this timezone data is known before the connection initiates, i find it reasonable to move it to the `_preconnect` functions of clients.

- not compiled and tested wfreerdp / directfb clients
- tested xfreerdp on ArchLinux. seems to be working ok.